### PR TITLE
build_targets: redesign target definition to be simpler

### DIFF
--- a/build_targets/__init__.py
+++ b/build_targets/__init__.py
@@ -141,7 +141,7 @@ class _BuildConfiguration():
         return list(map(
             lambda f: os.path.join(
                 rel_platform(self.platform),  # type: ignore
-                os.pathsep.join(f.split('/'))
+                *f.split('/'),
             ),
             files,
         ))
@@ -152,7 +152,7 @@ class _BuildConfiguration():
         return list(map(
             lambda f: os.path.join(
                 rel_target(self.name),  # type: ignore
-                os.pathsep.join(f.split('/'))
+                *f.split('/'),
             ),
             files,
         ))

--- a/build_targets/__init__.py
+++ b/build_targets/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import os
 import os.path
 import typing
@@ -76,6 +77,8 @@ class _BuildConfiguration():
         cross_toolchain: Union[Optional[str], bool] = False,
         linker_script: Optional[str] = None,
     ) -> None:
+        self.__log = logging.getLogger(self.__class__.__name__)
+
         # cross_toolchain == None: native
         # cross_toolchain == False: not specified
         if isinstance(cross_toolchain, bool):  # .-.
@@ -104,14 +107,17 @@ class _BuildConfiguration():
         '''
         for _cls in reversed(self.__class__.__mro__):  # __mro__ holds the inheritance chain
             cls = typing.cast(Type[_BuildConfiguration], _cls)
+            self.__log.debug(f'iterating over {cls}...')
             # call init, if defined
             if cls in self._init_calls:
+                self.__log.debug('calling init')
                 self._init_calls[cls](self)
             # append settings, if defined
             if hasattr(cls, '_setting_calls') and cls._setting_calls is not None:
                 for setting in ('source', 'include', 'c_flags', 'ld_flags'):
                     if setting in cls._setting_calls:
                         self._settings[setting] += cls._setting_calls[setting](self)
+                        self.__log.debug(f'appending {setting}, new value: {self._settings[setting]}')
 
     @property
     def main(self) -> str:

--- a/build_targets/__init__.py
+++ b/build_targets/__init__.py
@@ -90,6 +90,7 @@ class _BuildConfiguration():
         self._settings = {
             'source': [],
             'include': [rel_platform('generic')],
+            'include_files': [],
             'c_flags': ['-Os'],
             'ld_flags': [],
         }
@@ -115,7 +116,7 @@ class _BuildConfiguration():
                 self._init_calls[cls](self, kwargs)
             # append settings, if defined
             if hasattr(cls, '_setting_calls') and cls._setting_calls is not None:
-                for setting in ('source', 'include', 'c_flags', 'ld_flags'):
+                for setting in ('source', 'include', 'include_files', 'c_flags', 'ld_flags'):
                     if setting in cls._setting_calls:
                         self._settings[setting] += cls._setting_calls[setting](self)
                         self.__log.debug(f'appending {setting}, new value: {self._settings[setting]}')
@@ -176,6 +177,14 @@ class _BuildConfiguration():
         self._settings['include'] = value
 
     @property
+    def include_files(self) -> List[str]:
+        return self._settings['include_files']
+
+    @include_files.setter
+    def include_files(self, value: List[str]) -> None:
+        self._settings['include_files'] = value
+
+    @property
     def c_flags(self) -> List[str]:
         return self._settings['c_flags']
 
@@ -220,7 +229,7 @@ class _BuildConfigurationMeta(type):
     def __new__(mcs, name: str, bases: Tuple[Any], dic: Dict[str, Any]):  # type: ignore
         # save setting callbacks into _settings dictionary
         dic['_setting_calls'] = {}
-        for setting in ('source', 'include', 'c_flags', 'ld_flags'):
+        for setting in ('source', 'include', 'include_files', 'c_flags', 'ld_flags'):
             if setting in dic:
                 dic['_setting_calls'][setting] = dic.pop(setting)
 

--- a/build_targets/targets.py
+++ b/build_targets/targets.py
@@ -44,8 +44,8 @@ class STM32F1GenericTarget(families.STM32F1Family):
             'main.c',
         )
 
-    def include(self) -> List[str]:
-        return self.platform_files(
+    def include_files(self) -> List[str]:
+        return self.target_files(
             os.path.join('config', f'{self.config}.h'),
         )
 

--- a/build_targets/targets.py
+++ b/build_targets/targets.py
@@ -25,7 +25,7 @@ class LinuxUHIDTarget(families.NativeFamily, families.LinuxUHIDFamily):
         )
 
 
-class STM31F1GenericTarget(families.STM32F1Family):
+class STM32F1GenericTarget(families.STM32F1Family):
     name = 'stm32f1-generic'
 
     def init(self, args: Dict[str, Any]) -> None:

--- a/configure.py
+++ b/configure.py
@@ -124,20 +124,6 @@ class BuildSystemBuilder():
             nw.variable('ninja_required_version', '1.3')
             nw.newline()
 
-            # declare variables
-            nw.variable('root', self._root)
-            nw.variable('builddir', self._builddir)
-            nw.variable('cc', self._tool('gcc'))
-            nw.variable('ar', self._tool('ar'))
-            nw.variable('objcopy', self._tool('objcopy'))
-            nw.variable('size', self._tool('size'))
-            nw.variable('c_flags', self._target.c_flags)
-            nw.variable('c_include_flags', ' '.join([
-                f'-I{path}' for path in self._target.include
-            ]))
-            nw.variable('ld_flags', self._target.ld_flags)
-            nw.newline()
-
             # helper functions
             src = lambda f: os.path.join('$root', 'src', f)
             built = lambda f: os.path.join('$builddir', f)
@@ -149,6 +135,20 @@ class BuildSystemBuilder():
                 'out', '.'.join(filter(None, [file, ext]))
             ))
             binary_name = lambda file: extension(file, self._target.bin_extension)
+
+            # declare variables
+            nw.variable('root', self._root)
+            nw.variable('builddir', self._builddir)
+            nw.variable('cc', self._tool('gcc'))
+            nw.variable('ar', self._tool('ar'))
+            nw.variable('objcopy', self._tool('objcopy'))
+            nw.variable('size', self._tool('size'))
+            nw.variable('c_flags', self._target.c_flags)
+            nw.variable('c_include_flags', ' '.join([
+                f'-I{src(path)}' for path in self._target.include
+            ]))
+            nw.variable('ld_flags', self._target.ld_flags)
+            nw.newline()
 
             # declare rules
             nw.rule(

--- a/configure.py
+++ b/configure.py
@@ -178,6 +178,7 @@ class BuildSystemBuilder():
                     command='$objcopy -O binary $in $out',
                     description='BIN $out',
                 )
+                nw.newline()
 
             if self._target.generate_hex:
                 nw.rule(
@@ -185,6 +186,7 @@ class BuildSystemBuilder():
                     command='$objcopy -O ihex $in $out',
                     description='HEX $out',
                 )
+                nw.newline()
 
             # compile sources into objects
             objs = []

--- a/configure.py
+++ b/configure.py
@@ -17,6 +17,9 @@ import build_targets
 import build_targets.targets
 
 
+_MIN_PYTHON_VERSION = (3, 9)
+
+
 # disable colors if we're not in a TTY
 if sys.stdout.isatty():
     _RESET = '\33[0m'
@@ -288,6 +291,12 @@ class BuildSystemBuilder():
 
 
 if __name__ == '__main__':
+    if sys.version_info < _MIN_PYTHON_VERSION:
+        _error(
+            f'Unsupported Python version: {".".join(map(str, sys.version_info[:3]))}... '
+            f'You need at least Python {".".join(map(str, _MIN_PYTHON_VERSION))}.'
+        )
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--builddir',

--- a/configure.py
+++ b/configure.py
@@ -75,9 +75,11 @@ class BuildSystemBuilder():
         cli_args: List[str],
         target: str,
         builddir: str = 'build',
+        debug: bool = False,
         **kwargs: Any,
     ) -> None:
         self._cli_args = cli_args
+        self._debug = debug
 
         # get target
         if not target:
@@ -240,6 +242,15 @@ class BuildSystemBuilder():
         }.items():
             print('{:>24}: {}'.format(name, var))
 
+        if self._debug:
+            for name, entries in {
+                'source': self._target.source,
+                'include': self._target.include,
+            }.items():
+                print('{:>24}:'.format(name))
+                for entry in entries:
+                    print(' ' * 26 + entry)
+
     def _is_git_dirty(self) -> Optional[bool]:
         try:
             return bool(subprocess.check_output(['git', 'diff', '--stat']).decode().strip())
@@ -310,6 +321,12 @@ if __name__ == '__main__':
         '-t',
         type=str,
         help='override toolchain prefix (eg. arm-none-eabi)',
+    )
+    parser.add_argument(
+        '--debug',
+        '-d',
+        action='store_true',
+        help='output extra debug information',
     )
     target_subparsers = parser.add_subparsers(
         dest='target',

--- a/configure.py
+++ b/configure.py
@@ -211,7 +211,7 @@ class BuildSystemBuilder():
             if self._target.generate_bin:
                 nw.build(extension(out_name, 'bin'), 'bin', out)
                 nw.newline()
-            if self._target.generate_bin:
+            if self._target.generate_hex:
                 nw.build(extension(out_name, 'hex'), 'hex', out)
                 nw.newline()
 

--- a/configure.py
+++ b/configure.py
@@ -253,6 +253,8 @@ class BuildSystemBuilder():
                 'include_files': self._target.include_files,
             }.items():
                 print('{:>24}:'.format(name))
+                if not entries:
+                    print(' ' * 26 + '(empty)')
                 for entry in entries:
                     print(' ' * 26 + entry)
 

--- a/configure.py
+++ b/configure.py
@@ -146,6 +146,8 @@ class BuildSystemBuilder():
             nw.variable('c_flags', self._target.c_flags)
             nw.variable('c_include_flags', ' '.join([
                 f'-I{src(path)}' for path in self._target.include
+            ] + [
+                f'-include {src(path)}' for path in self._target.include_files
             ]))
             nw.variable('ld_flags', self._target.ld_flags)
             nw.newline()
@@ -248,6 +250,7 @@ class BuildSystemBuilder():
             for name, entries in {
                 'source': self._target.source,
                 'include': self._target.include,
+                'include_files': self._target.include_files,
             }.items():
                 print('{:>24}:'.format(name))
                 for entry in entries:


### PR DESCRIPTION
Currently, it is a bit hard for people without previous Python kowledge
to add new targets and platforms. The current design uses __init__ to
add any customizations, which is the correct way to do this in Python
code, but we are not really using this a Python code. This is suposed to
be a build target definition, which happens to use Python. Let's try to
simplify it.

It uses a metaclass to some magic handling of the methods defined in the
target class.

Signed-off-by: Filipe Laíns <lains@riseup.net>