### PR TITLE
stm32f1: startup: add missing include

### DIFF
--- a/src/platform/stm32f1/startup.c
+++ b/src/platform/stm32f1/startup.c
@@ -5,6 +5,8 @@
 
 #include <stm32f1xx.h>
 
+#include "util/types.h"
+
 /* Stack pointer */
 extern void _estack(); /* Not a function, just to be compatible with the vector table array */
 


### PR DESCRIPTION
I changed the types to u32 last minute, forgot to test compile.
