### PR TITLE
stm32f1: pass target config file to TinyUSB dependency

### DIFF
--- a/build_targets/targets.py
+++ b/build_targets/targets.py
@@ -7,7 +7,7 @@ import os.path
 
 from typing import Any, Dict, List
 
-from . import BuildConfigurationError, abs_target, families
+from . import BuildConfigurationError, abs_target, dependencies, families
 
 
 def _removesuffix(string: str, suffix: str) -> str:
@@ -49,6 +49,13 @@ class STM32F1GenericTarget(families.STM32F1Family):
             raise BuildConfigurationError(f'Unknown configuration for {self.name}: {self.config}')
 
         self.linker_script = os.path.join(self.name, f'{self.config}.ld')
+
+        assert isinstance(self.dependencies, list)
+        for dependency in self.dependencies:
+            if isinstance(dependency, dependencies.TinyUSBDependency):
+                dependency.include_files += self.target_files(
+                    os.path.join('config', f'{self.config}.h'),
+                )
 
     def source(self) -> List[str]:
         return self.target_files(

--- a/configure.py
+++ b/configure.py
@@ -109,7 +109,7 @@ class BuildSystemBuilder():
         # construct tool name, eg. arm-none-eabi-gcc, gcc...
         self._tool = lambda x: '-'.join(filter(None, [self._target.toolchain, x]))
 
-    def write_ninja(self, file: str = 'build.ninja') -> None:
+    def write_ninja(self, file: str = 'build.ninja') -> None:  # noqa: C901
         # delayed import to provide better UX
         try:
             import ninja_syntax
@@ -215,6 +215,12 @@ class BuildSystemBuilder():
                 c_include_flags = {
                     f'-I{path}' for path in dependency.include + dependency.dependencies_include
                 }
+                c_include_flags.update({
+                    f'-include {src(path)}' for path in dependency.include_files
+                })
+                c_include_flags.update({
+                    f'-I{src_dir}',
+                })
                 for file in set(dependency.source):
                     objs += cc_abs(file, variables=[('c_include_flags', list(c_include_flags))])
                 nw.newline()


### PR DESCRIPTION
This approach is not great, but the whole system is a mess and needs to
be rewritten either way.

Signed-off-by: Filipe Laíns <lains@riseup.net>