### PR TITLE
change tusb upstream to repo w src only, checkout v0.9.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "external/tinyusb"]
-	path = external/tinyusb
-	url = https://github.com/hathach/tinyusb
 [submodule "external/cmsis-5"]
 	path = external/cmsis-5
 	url = https://github.com/cmsis-packs/cmsis-5
@@ -10,3 +7,6 @@
 [submodule "external/sensor-blobs"]
 	path = external/sensor-blobs
 	url = https://github.com/openinput-fw/sensor-blobs
+[submodule "external/tinyusb"]
+	path = external/tinyusb
+	url = https://github.com/hathach/tinyusb_src

--- a/src/platform/stm32f1/usb.c
+++ b/src/platform/stm32f1/usb.c
@@ -84,8 +84,9 @@ void tud_resume_cb(void)
 }
 
 /* Invoked when received GET_REPORT control request */
-u16 tud_hid_get_report_cb(u8 report_id, hid_report_type_t report_type, u8 *buffer, u16 reqlen)
+u16 tud_hid_get_report_cb(u8 itf, u8 report_id, hid_report_type_t report_type, u8 *buffer, u16 reqlen)
 {
+	(void) itf;
 	(void) report_id;
 	(void) report_type;
 	(void) buffer;
@@ -95,8 +96,9 @@ u16 tud_hid_get_report_cb(u8 report_id, hid_report_type_t report_type, u8 *buffe
 }
 
 /* Invoked when received SET_REPORT control request */
-void tud_hid_set_report_cb(u8 report_id, hid_report_type_t report_type, u8 const *buffer, u16 bufsize)
+void tud_hid_set_report_cb(u8 itf, u8 report_id, hid_report_type_t report_type, u8 const *buffer, u16 bufsize)
 {
+	(void) itf;
 	(void) report_id;
 	(void) report_type;
 	(void) buffer;

--- a/src/platform/stm32f1/usb_descriptors.c
+++ b/src/platform/stm32f1/usb_descriptors.c
@@ -119,8 +119,10 @@ u8 const *tud_descriptor_device_cb(void)
 /* Invoked when received GET HID REPORT DESCRIPTOR */
 /* Application return pointer to descriptor */
 /* Descriptor contents must exist long enough for transfer to complete */
-u8 const *tud_hid_descriptor_report_cb(void)
+u8 const *tud_hid_descriptor_report_cb(u8 itf)
 {
+	(void) itf;
+
 	memcpy(desc_hid_report, oi_rdesc, sizeof(oi_rdesc)); /* protocol report descriptor */
 	memcpy(desc_hid_report + sizeof(oi_rdesc),
 	       desc_hid_mouse_report,


### PR DESCRIPTION
external: tinyusb: change upstream to repo w only the src, checkout v0.9.0

Signed-off-by: Rafael Silva <silvagracarafael@gmail.com>