### PR TITLE
 docs: change favicon to logo without text

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ exclude_patterns = []
 html_theme = 'furo'
 html_title = 'openinput'
 html_logo = 'assets/logo.svg'
-html_favicon = 'assets/logo.svg'
+html_favicon = 'assets/logo_icon.svg'
 html_theme_options = {
     'sidebar_hide_name': True,
 }


### PR DESCRIPTION
Logo is used in a couple different places/repos, maybe we could make a repo for them and have everything else reference them through the raw github links.

i didn't pr that because im not sure links are ok with the docs in this case?