### PR TITLE
docs: sammy official hardware link

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -103,6 +103,7 @@ After this, you should have you shiny new object in ``build/out``.
    :hidden:
 
    Big-sammy <https://big-sammy.readthedocs.io>
+   Sammy <https://sammy.readthedocs.io>
 
 
 .. toctree::


### PR DESCRIPTION
I would only add this when we have barebones fw working

https://openinput.readthedocs.io/projects/sammy/en/latest/