### PR TITLE
 github: remove FUNDING.yml file

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-open_collective: openinput


### PR DESCRIPTION
This file is overriding the organization-wide FUNDING.yml file. Removing FUNDING.yml in this repository will use the organization default.