### PR TITLE
docs: add fixed jinja2 requirement

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx~=3.0
 furo>=2020.12.30.b24
 sphinxemoji>=0.1.8
 sphinx-autodoc-typehints>=1.10
+jinja2<=3.0.3


### PR DESCRIPTION
jinja2 updated to 3.1.0 / 3.1.1 which broke the docs building, fix it to a known working version