### PR TITLE
Fix actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,10 @@ jobs:
       run: pip install ninja_syntax
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.0.2
+
+    - name: Container permissions
+      run: git config --global --add safe.directory '*'
 
     - name: Configure
       run: ./configure.py ${{ matrix.target }}
@@ -56,7 +59,10 @@ jobs:
       run: pip install ninja_syntax tomli
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.0.2
+
+    - name: Container permissions
+      run: git config --global --add safe.directory '*'
 
     - name: Configure
       run: ./configure-oss-fuzz.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,10 @@ jobs:
       run: pacman -Syu --noconfirm --noprogressbar --needed clang git python-pip
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.0.2
+
+    - name: Container permissions
+      run: git config --global --add safe.directory '*'
 
     - name: Run pre-commit
-      uses: pre-commit/action@v2.0.0
+      uses:  before-commit/run-action@v2.0.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,12 +27,15 @@ jobs:
       run: pip install nox
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.0.2
+
+    - name: Container permissions
+      run: git config --global --add safe.directory '*'
 
     - name: Run tests
       run: nox -s test
 
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v3.1.0
       if: ${{ always() }}
 
   fuzz:
@@ -54,12 +57,15 @@ jobs:
       run: pip install nox
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.0.2
+
+    - name: Container permissions
+      run: git config --global --add safe.directory '*'
 
     - name: Run fuzzing session
       run: nox -s "fuzz(sanitizer='${{ matrix.sanitizer }}')"
 
     - name: Archive crashes
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.0
       with:
         path: crash-*


### PR DESCRIPTION
Git v2.35.3 added a security check that broke actions ran on containers, this works around that, and bumps the action versions while at it

Signed-off-by: Rafael Silva <rafaelsilva@ajtec.pt>